### PR TITLE
Extend color options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  build-linux:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
     steps:
     - uses: actions/checkout@v3
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        cache: true
     - name: Build & test library
-      run: cargo test --lib
-    - name: Build binary
-      run: cargo build --bins
+      run: cargo test --lib --no-default-features
+    - name: Build & test binary
+      run: cargo test --bins --features cli

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ exclude = ["outputs/*", "samples/*"]
 [features]
 default = ["cli"]
 cli = ["clap"]
-l1 = []
 
 [lib]
 name = "retroimg"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![Latest Version](https://img.shields.io/crates/v/retroimg.svg)](https://crates.io/crates/retroimg) [![Continuous integration status](https://github.com/Enet4/retroimg/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Enet4/retroimg/actions/workflows/ci.yml) [![dependency status](https://deps.rs/repo/github/Enet4/retroimg/status.svg)](https://deps.rs/repo/github/Enet4/retroimg)
 
 Convert images to appear to be reproduced on retro IBM hardware.
+It can also be used to reduce the color depth of existing images
+for use in DOS game development.
+
 
 | original (640x480, 24-bit RGB) | VGA (320x200, 256 colors, 4:5 pixels) | EGA (320x200, 16 colors, 4:5 pixels) | CGA (320x200, 4 colors + bkg) |
 |--------------------------------|---------------------------------------|--------------------------------------|----------------|
@@ -14,6 +17,8 @@ The full image processing pipeline is composed of the following steps:
 1. Image cropping and resizing to a low resolution;
 2. Master palette color quantization and mapping to a restricted color palette, plus color limit with dithering;
 3. Nearest-neighbor resizing to a high resolution, to make pixels look good, also enabling non-square pixels.
+
+Each step can be tweaked or skipped to suit your wishes.
 
 **Note:** This application does not claim to achieve a perfect emulation of old hardware,
 but it should hopefully attain sufficiently good results for the intended nostalgia kick.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The main options are:
   - `true` or `24bit`: 24-bit RGB color depth
 - `-R WxH`: the resolution to resize the image into.
 - `-S WxH`: the full image output size, resized from the previous option.
+- `-l L2` or `-l L2`: the color distance/loss algorithm to use for color palette selection
 
 To convert an image to look like it was presented in VGA mode 13h,
 with non-square pixels:

--- a/src/color.rs
+++ b/src/color.rs
@@ -83,7 +83,10 @@ fn color_diff_l2(c1: Color, c2: Color) -> u64 {
     let dg = (g1 - g2) as u64;
     let db = (b1 - b2) as u64;
 
-    (dr * dr + dg * dg + db * db).sqrt()
+    (dr.saturating_mul(dr)
+        .saturating_add(dg.saturating_mul(dg))
+        .saturating_add(db.saturating_mul(db)))
+    .sqrt()
 }
 
 /// calculate the median RGB color of the given buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+//! Retroimg processing library.
+//! 
+//! Convert images to appear to be displayed on retro IBM hardware.
+//! It can also be used to reduce the color depth of existing images
+//! for use in DOS game development.
 use image::imageops::{resize, FilterType};
 use image::{GenericImage, ImageBuffer, Pixel, RgbImage};
 use num_rational::Ratio;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use lib::color::{ColorOptions, LossAlgorithm};
 use num_integer::Integer;
 use num_rational::Ratio;
 use std::path::PathBuf;
@@ -15,11 +16,7 @@ pub struct App {
     input: PathBuf,
 
     /// Output image file path
-    #[clap(
-        short = 'o',
-        long = "out",
-        default_value = "out.png",
-    )]
+    #[clap(short = 'o', long = "out", default_value = "out.png")]
     output: PathBuf,
 
     /// Color standard
@@ -50,6 +47,10 @@ pub struct App {
     /// Maximum number of simultaneous colors (emulates palette indexing)
     #[clap(short = 'c', long = "num-colors", default_value = "256")]
     num_colors: u16,
+
+    /// Color distance algorithm for loss calculation (L1 or L2)
+    #[clap(short = 'l', long = "loss", default_value = "L2")]
+    loss: LossAlgorithm,
 
     /// Print some info to stderr
     #[clap(short = 'v', long = "verbose")]
@@ -186,6 +187,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         standard,
         no_color_limit,
         num_colors,
+        loss,
         verbose,
     } = App::parse();
 
@@ -236,7 +238,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ColorStandard::BlackWhite => Box::new(lib::color::PALETTE_BW_1BIT),
     };
 
-    let colorbuffer = depth.convert_image(&img, num_colors);
+    let colorbuffer = depth.convert_image(&img, ColorOptions { num_colors, loss });
     let img = lib::color::colors_to_image(img.width(), img.height(), colorbuffer);
     let img = lib::expand(&img, out_width, out_height);
 


### PR DESCRIPTION
### Summary

- use saturating multiplications and additions to prevent L2 color diff from overflowing
- add loss algorithm to run-time as a color option
- add lib root crate documentation
- Update CI workflow
- Tweak readme